### PR TITLE
Add docker run script

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+#
+# Run a docker container after cleaning up any existing container with the same name
+# 
+# Usage:
+#   docker-run.sh <name> [<extra-docker-run-argument> ...]
+#
+# Example:
+#   docker-run.sh my-container --link redis:redis -p 8080:8080 group/container-type
+
+USAGE="Usage: $0 <name> [<extra-docker-run-argument> ...]"
+if [ "$#" == "0" ]; then
+    echo "$USAGE"
+    exit 1
+fi
+
+CONTAINER_NAME="$1"
+shift
+
+docker rm -f "$CONTAINER_NAME" || true
+docker run --rm --name="$CONTAINER_NAME" "$@"


### PR DESCRIPTION
Add a script that will first try to delete the existing docker container before trying to run it. This is a problem if you're trying to automatically stop and start containers to get a new version, but the container already exists (in some conditions the container doesn't get deleted when being stopped), leading to a restarting of the container to fail indefinitely.
