### PR TITLE
Explicitly set metrics API RabbitMQ credentials

### DIFF
--- a/docker-vms/metrics_api/vumi_metrics_api.yaml
+++ b/docker-vms/metrics_api/vumi_metrics_api.yaml
@@ -11,3 +11,9 @@ backend:
     graphite_url: 'http://graphite/'
     username: 'api'
     password: 'api'
+
+    amqp_hostname: 'rabbitmq'
+    amqp_port: 5672
+    amqp_username: 'guest'
+    amqp_password: 'guest'
+    amqp_vhost: '/'


### PR DESCRIPTION
Out of respect for our future selves who would otherwise have to read the defaults in the code to know what is going on.
